### PR TITLE
Fix incompatibilty with Markdown>=3.0

### DIFF
--- a/markup_deprecated/templatetags/markup.py
+++ b/markup_deprecated/templatetags/markup.py
@@ -68,10 +68,10 @@ def markdown(value, arg=''):
             if extensions and extensions[0] == "safe":
                 extensions = extensions[1:]
                 return mark_safe(markdown.markdown(
-                    force_text(value), extensions, safe_mode=True, enable_attributes=False))
+                    force_text(value), extensions=extensions, safe_mode=True, enable_attributes=False))
             else:
                 return mark_safe(markdown.markdown(
-                    force_text(value), extensions, safe_mode=False))
+                    force_text(value), extensions=extensions, safe_mode=False))
 
 @register.filter(is_safe=True)
 def restructuredtext(value):


### PR DESCRIPTION
The package Markdown in version 3.0 did break compatibility with django-markup-deprectated==0.0.3. See also https://python-markdown.github.io/change_log/release-3.0/ chapter Backwards-incompatible changes/Positional arguments deprecated.

This patch creates compatibility with Markdown>=3.0 while still being compatible with older versions of the Markdown package.